### PR TITLE
feat: Integrate mcp-use and Context7

### DIFF
--- a/examples/context7.json
+++ b/examples/context7.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "langchain-mcp-adapters>=0.0.5",
     "langchain-deepseek>=0.1.2",
     "langchain-text-splitters>=0.3.7",
+    "mcp-use>=1.2.7",
 ]
 
 [project.optional-dependencies]

--- a/ra_aid/prompts/research_prompts.py
+++ b/ra_aid/prompts/research_prompts.py
@@ -111,6 +111,9 @@ If you find this is an empty directory, you can stop research immediately and as
 {expert_section}
 {human_section}
 {web_research_section}
+    Context7 Tool Guidance:
+        If the task involves understanding or using specific libraries, frameworks, or APIs (e.g., React, Next.js, pandas, AWS SDK, Stripe API), **strongly prioritize** using the `resolve-library-id` and `get-library-docs` tools (if available) to fetch the most current documentation and examples *before* relying solely on your internal knowledge or web searches. Outdated information can lead to errors. Clearly state which library you are fetching documentation for when using these tools.
+
 {custom_tools_section}
 
     You have often been criticized for:

--- a/ra_aid/tool_configs.py
+++ b/ra_aid/tool_configs.py
@@ -36,6 +36,8 @@ from ra_aid.tools.memory import plan_implementation_completed
 from ra_aid.database.repositories.config_repository import get_config_repository
 
 # Define constant tool groups
+from ra_aid.utils.mcp_use_client import MCPUseClientSync
+
 CUSTOM_TOOLS = []
 
 def set_modification_tools(use_aider=False):
@@ -106,6 +108,15 @@ def get_custom_tools() -> List[BaseTool]:
             console.print(Panel(Markdown(custom_tool_output.strip()), title="🛠️ Custom Tools Available", border_style="magenta"))
 
         # Set global
+        # Integrate MCP-Use tools if config provided
+        mcp_use_cfg = get_config_repository().get("mcp_use_config", None)
+        if mcp_use_cfg:
+            try:
+                mcp_client = MCPUseClientSync(mcp_use_cfg)
+                tools.extend(mcp_client.get_tools_sync())
+            except Exception as e:
+                console.print(Panel(f"[red]Failed to load MCP-Use tools: {e}"))
+
         CUSTOM_TOOLS.clear()
         CUSTOM_TOOLS.extend(tools)
 

--- a/ra_aid/utils/mcp_use_client.py
+++ b/ra_aid/utils/mcp_use_client.py
@@ -1,0 +1,75 @@
+import asyncio
+import threading
+from typing import Any, List
+
+from langchain_core.tools import BaseTool
+from mcp_use import MCPClient
+from mcp_use.adapters.langchain_adapter import LangChainAdapter
+
+
+class MCPUseClientSync:
+    """Synchronous wrapper around ``mcp_use.MCPClient``.
+
+    ``mcp_use`` is fully async; RA.Aid’s tool-pipeline expects plain
+    synchronous ``langchain_core.tools.BaseTool`` instances.  This wrapper
+    starts a background event-loop, initializes the MCP client and converts
+    every server tool to a ``StructuredTool`` via the official
+    ``LangChainAdapter``.
+    """
+
+    def __init__(self, config: str | dict[str, Any]):
+        """Create the client.
+
+        Args:
+            config: Either a path to a JSON config file **or** a config dict
+                    compatible with ``MCPClient``.
+        """
+        self.loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(target=self._run_loop, daemon=True)
+        self.thread.start()
+
+        self._client: MCPClient | None = None
+        self._tools: List[BaseTool] = []
+
+        fut = asyncio.run_coroutine_threadsafe(
+            self._setup_client(config), self.loop
+        )
+        fut.result()  # propagate any exceptions synchronously
+
+    # ---------------------------------------------------------------------
+    # public helpers
+    # ---------------------------------------------------------------------
+    def get_tools_sync(self) -> List[BaseTool]:
+        """Return the converted LangChain tools (synchronous)."""
+        return self._tools
+
+    def close(self) -> None:
+        """Close all MCP sessions and stop the event-loop."""
+        if self._client is not None:
+            fut = asyncio.run_coroutine_threadsafe(
+                self._client.close_all_sessions(), self.loop
+            )
+            fut.result()
+
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self.thread.join(timeout=5)
+
+    # ------------------------------------------------------------------
+    # internal
+    # ------------------------------------------------------------------
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
+
+    async def _setup_client(self, config: str | dict[str, Any]):
+        if isinstance(config, str):
+            client = MCPClient.from_config_file(config)
+        else:
+            client = MCPClient.from_dict(config)
+
+        # create sessions for all declared servers so tools are available
+        await client.create_all_sessions(auto_initialize=True)
+
+        adapter = LangChainAdapter()
+        self._tools = await adapter.create_tools(client)
+        self._client = client

--- a/ra_aid/utils/mcp_use_client.py
+++ b/ra_aid/utils/mcp_use_client.py
@@ -14,6 +14,11 @@ class MCPUseClientSync:
     synchronous ``langchain_core.tools.BaseTool`` instances.  This wrapper
     starts a background event-loop, initializes the MCP client and converts
     every server tool to a ``StructuredTool`` via the official
+    Note:
+        Using MCP servers often requires external dependencies managed by that
+        server. For example, using the Context7 server requires ``npx`` (Node.js)
+        to be available in the environment to run ``@upstash/context7-mcp``.
+
     ``LangChainAdapter``.
     """
 


### PR DESCRIPTION
Integrates the mcp-use library for enhanced MCP client capabilities and adds support for the Context7 MCP server to provide up-to-date documentation context to the LLM.

Changes:
- Added `mcp-use` to dependencies.
- Created `ra_aid/utils/mcp_use_client.py` as a sync wrapper.
- Added `--mcp-use-config` and `--no-context7` CLI flags (Context7 now enabled by default).
- Integrated MCP-Use tool loading in `ra_aid/tool_configs.py`.
- Added default `context7.json` config in `examples/`.
- Updated Research agent prompt to encourage proactive use of Context7.

**Update:** Addressed review comments:
- Implemented resource cleanup for `MCPUseClientSync` using `atexit`.
- Added note about Node.js dependency to `MCPUseClientSync` docstring.
- Added CLI flag examples to `__main__.py` help text.
- Improved "Context7 config not found" error message.
- Improved logging for MCP tool loading.