### PR TITLE
fix: Display status panel immediately in interactive mode

### DIFF
--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -959,7 +959,10 @@ def run_interactive_mode(args, mcp_use_client_instance=None):
         logger.debug(f"Error initializing config repository: {e}")
         
     # --- NEW: Display initial status ---    
-    console.print(Panel(build_status(), title="Status", border_style="blue"))
+    try:
+        console.print(Panel(build_status(), title="Status", border_style="blue"))
+    except Exception as e:
+        logger.debug(f"Initial status display failed: {e}")
     # --- END NEW ---
     
     try:

--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -957,6 +957,10 @@ def run_interactive_mode(args, mcp_use_client_instance=None):
         ConfigRepositoryManager.initialize()
     except Exception as e:
         logger.debug(f"Error initializing config repository: {e}")
+        
+    # --- NEW: Display initial status ---    
+    console.print(Panel(build_status(), title="Status", border_style="blue"))
+    # --- END NEW ---
     
     try:
         while True:


### PR DESCRIPTION
This pull request introduces a small but user-friendly enhancement to the `run_interactive_mode` function in `ra_aid/__main__.py`. It adds an initial status display panel to provide users with immediate feedback when entering interactive mode.

* [`ra_aid/__main__.py`](diffhunk://#diff-aad78adcd442a7057d369a36719a86e775eb21f2ead488b00a91eb2550fe85deR961-R964): Added a new panel displaying the initial status using the `build_status()` function, styled with a blue border and a "Status" title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - An initial status panel is now displayed immediately after starting interactive mode, providing a summary of current settings and resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->