### PR TITLE
fix: Ensure MCP status displays correctly in interactive mode

### DIFF
--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -951,14 +951,9 @@ def run_interactive_mode(args, mcp_use_client_instance=None):
     """Run RA.Aid in interactive mode with a command prompt."""
     display_welcome_message()
     
-    # Ensure config repository is initialized
-    try:
-        from ra_aid.database.repositories.config_repository import ConfigRepositoryManager
-        ConfigRepositoryManager.initialize()
-    except Exception as e:
-        logger.debug(f"Error initializing config repository: {e}")
+    # Config repository is initialized within the main() context manager
         
-    # --- NEW: Display initial status ---    
+    # --- Display initial status ---    
     try:
         console.print(Panel(build_status(), title="Status", border_style="blue"))
     except Exception as e:


### PR DESCRIPTION
## Overview

This PR addresses an issue where the active MCP servers were not displayed in the status panel when entering interactive mode directly (without an initial task).

## Changes

- Removed a redundant call to `ConfigRepositoryManager.initialize()` within `run_interactive_mode`. This call was potentially interfering with the config context established earlier in `main`, preventing the `build_status` function from accessing the list of active MCP servers.

## Testing

- Verified that running `ra-aid` without arguments now correctly displays the initial status panel, including the `🔌 MCP Servers:` line, before showing the interactive prompt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved initialization flow by removing redundant configuration setup in interactive mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->