### PR TITLE
feat: Add wait time and message for MCP server initialization

### DIFF
--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 import json
+import time # <-- ADDED IMPORT
 from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -1064,6 +1065,12 @@ def main():
                         logger.info("Attempting to initialize MCP-Use client...")
                         mcp_use_client_instance = MCPUseClientSync(mcp_use_config)
                         atexit.register(mcp_use_client_instance.close)
+                        
+                        # --- NEW: Wait for servers and show message ---
+                        console.print("[yellow]Initializing MCP servers (waiting 20s)...[/yellow]")
+                        time.sleep(20)
+                        # --- END NEW ---
+                        
                         logger.debug("MCPUseClientSync instance created. Getting active servers...")
                         active_mcp_servers = mcp_use_client_instance.get_active_server_names()
                         logger.info(f"MCP-Use client initialized. Active servers: {active_mcp_servers}")


### PR DESCRIPTION
## Overview

This PR attempts to address the issue where MCP servers might not be fully initialized before their status is checked, potentially causing them not to appear in the status panel.

## Changes

- Added `import time`.
- Added a 20-second `time.sleep(20)` after creating the `MCPUseClientSync` instance but before calling `get_active_server_names()`.
- Added a console message `[yellow]Initializing MCP servers (waiting 20s)...[/yellow]` to inform the user during the wait.

## Purpose

To give external MCP server processes sufficient time to start up before the application attempts to query their status.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visible console message indicating a 20-second initialization wait for MCP servers during startup.

- **Style**
  - Console output now includes a highlighted message to inform users about the initialization delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->