### PR TITLE
fix: Correct path for loading default MCP config file

### DIFF
--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -1205,16 +1205,16 @@ def main():
                 
                 default_config_dict = {}
                 if should_load_defaults:
-                    logger.debug("Attempting to load default MCP config...") # <-- ADDED
+                    logger.debug("Attempting to load default MCP config...")
                     try:
-                        default_mcp_config_path_obj = pkg_resources.files("ra_aid").joinpath("examples/default_mcp_servers.json")
-                        logger.debug(f"Default config path object: {default_mcp_config_path_obj}") # <-- ADDED
-                        if default_mcp_config_path_obj.is_file():
-                            default_config_file_path = str(default_mcp_config_path_obj)
+                        # Corrected path relative to project root
+                        default_config_file_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../examples/default_mcp_servers.json')) 
+                        logger.debug(f"Looking for default config at: {default_config_file_path}")
+                        if os.path.isfile(default_config_file_path):
                             logger.info(f"Loading default MCP server config: {default_config_file_path}")
                             with open(default_config_file_path, 'r') as f:
                                 default_config_dict = json.load(f)
-                            logger.debug(f"Default config loaded: {list(default_config_dict.get('mcpServers', {}).keys())}") # <-- ADDED
+                            logger.debug(f"Default config loaded: {list(default_config_dict.get('mcpServers', {}).keys())}")
 
                             # Filter based on --disable-default-mcp list
                             if isinstance(disabled_defaults, list):


### PR DESCRIPTION
This pull request includes a change to the `main()` function in `ra_aid/__main__.py` to correct the method of locating the default MCP server configuration file. The most important change ensures the file path is resolved relative to the project root, improving reliability when loading the default configuration.

### Changes to file path resolution:

* [`ra_aid/__main__.py`](diffhunk://#diff-aad78adcd442a7057d369a36719a86e775eb21f2ead488b00a91eb2550fe85deL1208-R1217): Replaced `pkg_resources`-based path resolution with `os.path.abspath` to correctly resolve the path of `examples/default_mcp_servers.json` relative to the project root. This ensures compatibility across different environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling and fallback behavior when loading the default MCP server configuration.
- **Enhancements**
	- Added detailed debug logging for configuration loading, filtering, and merging processes.
	- Provided clearer warnings and error messages if configuration files are missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->